### PR TITLE
chore: adds export `ImageResponseOptions`

### DIFF
--- a/packages/next/server.d.ts
+++ b/packages/next/server.d.ts
@@ -12,3 +12,4 @@ export { userAgentFromString } from 'next/dist/server/web/spec-extension/user-ag
 export { userAgent } from 'next/dist/server/web/spec-extension/user-agent'
 export { URLPattern } from 'next/dist/compiled/@edge-runtime/primitives/url'
 export { ImageResponse } from 'next/dist/server/web/spec-extension/image-response'
+export type { ImageResponseOptions } from 'next/dist/compiled/@vercel/og/types'


### PR DESCRIPTION
Exports `ImageResponseOptions` from `next/server`.

## Rationale

Today I do this:

```ts
import { ImageResponseOptions } from "next/dist/compiled/@vercel/og/types";
import { ImageResponse } from "next/server";

export const config = { runtime: "edge" };

export const GET = async (req: Request) => {
  const inter = await getFont({
    family: "Inter",
    weights: [400, 700],
  });

  const options: ImageResponseOptions = {
    width: 1200,
    height: 600,
    fonts: [
      { name: "Inter", data: inter[400], weight: 400 },
      { name: "Inter", data: inter[700], weight: 700 },
    ],
  };

  if (someCond) {
    return new ImageResponse(<>Some JSX</>, options);
  }
  
  // ...

  return new ImageResponse(<>Some other JSX</>, options);
};
```

And I never like importing stuff from an internal path such as `dist/compiled/...`.